### PR TITLE
fix(transcode): stable VOD playlist + long-poll segments for HLS cold-start (#24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,4 +120,6 @@ adds unaffected), `VAULTTUBE_DBPOOL` (DB connection pool size, default 8),
 cache TTL in seconds, default 86400), `VAULTTUBE_TRANSCODE_MAX_CACHE_GB`
 (max cache size in GB, default 50), `VAULTTUBE_TRANSCODE_PRESET` (libx264
 preset, default `veryfast`), `VAULTTUBE_TRANSCODE_CRF` (libx264 quality,
-default 23), `VAULTTUBE_MAX_CONCURRENT_TRANSCODES` (default 1).
+default 23), `VAULTTUBE_MAX_CONCURRENT_TRANSCODES` (default 1),
+`VAULTTUBE_TRANSCODE_SEGMENT_TIMEOUT` (seconds a segment request long-polls
+for a not-yet-produced segment before 404-ing, default 30).

--- a/app/api.py
+++ b/app/api.py
@@ -11,7 +11,7 @@ import requests
 
 from QueueObject import QueueObject
 from queue_utils import enqueue
-from transcoder import generate_hls, touch_cache_access, note_segment_request, is_apple_direct, get_codec_info, get_container_from_ext, get_transcode_cache_dir
+from transcoder import generate_hls, touch_cache_access, note_segment_request, is_apple_direct, get_codec_info, get_container_from_ext, get_transcode_cache_dir, get_duration, build_vod_playlist, segment_count_for_duration, wait_for_segment, transcode_key, source_path_for
 from werkzeug.exceptions import HTTPException
 
 api_bp = Blueprint('api',__name__)
@@ -940,13 +940,33 @@ def api_stats():
     
 @api_bp.route('/transcode/<string:video_id>/playlist.m3u8')
 def transcode_playlist(video_id):
-    """Return an HLS playlist for video_id. Launches FFmpeg on demand."""
+    """Return a stable VOD HLS playlist for video_id. Launches FFmpeg on demand.
+
+    The playlist is synthesized from the source duration so it carries the
+    full segment list, #EXT-X-PLAYLIST-TYPE:VOD and #EXT-X-ENDLIST from the
+    very first request — even while the transcode is still in progress. This
+    keeps HLS clients (AVPlayer) in VOD mode playing from seg_00000 instead of
+    latching the live edge of an endless playlist (issue #24). Segments that
+    aren't on disk yet block in the segment endpoint rather than 404-ing.
+    """
     try:
         current_app.logger.debug('Called HLS playlist for: %s', video_id)
-        cache_dir = generate_hls(video_id, current_app.logger)
+        source_path = source_path_for(video_id, current_app.logger)
+        if not source_path or not os.path.isfile(source_path):
+            abort(404)
+
+        # Kick off (or confirm) the encode so segments start being produced.
+        cache_dir = generate_hls(video_id, current_app.logger, source_path=source_path)
         if not cache_dir:
             abort(404)
         touch_cache_access(video_id)
+
+        body = build_vod_playlist(get_duration(source_path, current_app.logger))
+        if body is not None:
+            return current_app.response_class(
+                body, mimetype='application/vnd.apple.mpegurl')
+
+        # Duration unknown — fall back to FFmpeg's own (live) playlist.
         playlist_path = os.path.join(cache_dir, 'playlist.m3u8')
         if not os.path.exists(playlist_path):
             abort(404)
@@ -964,21 +984,51 @@ def transcode_playlist(video_id):
 
 @api_bp.route('/transcode/<string:video_id>/seg_<string:segment>.ts')
 def transcode_segment(video_id, segment):
-    """Serve a single HLS segment from the transcode cache."""
+    """Serve a single HLS segment, blocking until it's produced if needed.
+
+    The synthesized VOD playlist lists every segment up front, so clients will
+    request segments the transcode hasn't reached yet. Rather than 404-ing
+    instantly (which fails the AVPlayer item — issue #24), we long-poll until
+    FFmpeg writes the segment, restarting the encode if it isn't running.
+    A genuine out-of-range index or a timeout still 404s.
+    """
     try:
         current_app.logger.debug('Called HLS segment %s for: %s', segment, video_id)
         if not segment.isdigit():
             abort(404)
+        index = int(segment)
         cache_dir = get_transcode_cache_dir(video_id)
-        seg_path = os.path.join(cache_dir, 'seg_%05d.ts' % int(segment))
+        seg_path = os.path.join(cache_dir, 'seg_%05d.ts' % index)
         real_cache = os.path.realpath(cache_dir)
         real_seg = os.path.realpath(seg_path)
         if not real_seg.startswith(real_cache + os.sep):
             abort(404)
-        if not os.path.isfile(real_seg):
-            note_segment_request(video_id)  # still counts as interest
-            touch_cache_access(video_id)
-            abort(404)
+
+        note_segment_request(video_id)
+        touch_cache_access(video_id)
+
+        # Fast path: already on disk.
+        if not (os.path.isfile(real_seg) and os.path.getsize(real_seg) > 0):
+            source_path = source_path_for(video_id, current_app.logger)
+            if not source_path or not os.path.isfile(source_path):
+                abort(404)
+
+            # Reject indices beyond the real end of the video.
+            total = segment_count_for_duration(get_duration(source_path, current_app.logger))
+            if total and index >= total:
+                abort(404)
+
+            # Ensure an encode is running (it may have been reaped mid-session).
+            generate_hls(video_id, current_app.logger, source_path=source_path)
+
+            timeout = _segment_wait_timeout()
+            ready = wait_for_segment(
+                cache_dir, index, transcode_key(video_id), timeout=timeout)
+            if not ready:
+                current_app.logger.warning(
+                    "HLS segment %s timed out/unavailable for %s", index, video_id)
+                abort(404)
+
         note_segment_request(video_id)
         touch_cache_access(video_id)
         resp = send_file(
@@ -993,6 +1043,13 @@ def transcode_segment(video_id, segment):
     except Exception as e:
         current_app.logger.error("HLS segment failed for %s/%s: %s", video_id, segment, e)
         return api_error(str(e), 500)
+
+
+def _segment_wait_timeout():
+    try:
+        return max(1.0, float(os.environ.get('VAULTTUBE_TRANSCODE_SEGMENT_TIMEOUT', '30')))
+    except ValueError:
+        return 30.0
 
 
 # Legacy transcoding endpoint removed; use /api/transcode/<id>/playlist.m3u8

--- a/app/transcoder.py
+++ b/app/transcoder.py
@@ -1,4 +1,4 @@
-import json, os, re, subprocess, threading, time, shutil, glob, hashlib
+import json, math, os, re, subprocess, threading, time, shutil, glob, hashlib
 from pathlib import Path
 
 _FFPROBE_LOCK = threading.Lock()
@@ -64,6 +64,48 @@ def get_container_from_ext(filepath):
     return ext if ext else None
 
 
+_DURATION_LOCK = threading.Lock()
+_duration_cache = {}
+
+
+def get_duration(filepath, logger=None):
+    """Return the source duration in seconds (float) via ffprobe, or None.
+
+    Cached per (path, mtime) like get_codec_info. Used to synthesize a
+    complete VOD playlist before the transcode has finished.
+    """
+    filepath = os.path.abspath(filepath)
+    key = _ffprobe_key(filepath)
+    with _DURATION_LOCK:
+        cached = _duration_cache.get(filepath)
+        if cached and cached[0] == key:
+            return cached[1]
+
+    duration = None
+    try:
+        output = subprocess.check_output(
+            [
+                'ffprobe', '-v', 'quiet',
+                '-print_format', 'json',
+                '-show_format',
+                filepath,
+            ],
+            stderr=subprocess.STDOUT,
+            timeout=60,
+        )
+        data = json.loads(output.decode('utf-8', errors='replace'))
+        raw = data.get('format', {}).get('duration')
+        if raw is not None:
+            duration = float(raw)
+    except Exception as e:
+        if logger:
+            logger.error("ffprobe duration failed for %s: %s", filepath, e)
+
+    with _DURATION_LOCK:
+        _duration_cache[filepath] = (key, duration)
+    return duration
+
+
 def is_apple_direct(vcodec, acodec, container):
     """True if this streams H.264 video + AAC audio in an MP4-ish container."""
     if not vcodec or not acodec or not container:
@@ -81,6 +123,11 @@ def is_apple_direct(vcodec, acodec, container):
 _active = {}            # key -> {'process': Popen, 'last_request': float, 'dir': str}
 _active_lock = threading.Lock()
 _settings_order = ['preset', 'crf', 'vcodec', 'acodec', 'video_filter']
+
+# Target HLS segment length. Keyframes are forced at multiples of this so the
+# produced segment count is deterministic (ceil(duration / SEGMENT_SECONDS))
+# and a synthesized VOD playlist matches the segments FFmpeg actually writes.
+SEGMENT_SECONDS = 6
 
 
 def _settings_hash(settings):
@@ -106,6 +153,16 @@ def get_transcode_settings():
         'acodec': 'aac',
         'video_filter': 'format=yuv420p',
     }
+
+
+def transcode_key(video_id, settings=None):
+    """The (video_id, settings_hash) key used to track a live encode."""
+    return (video_id, _settings_hash(settings or get_transcode_settings()))
+
+
+def source_path_for(video_id, logger):
+    """Public wrapper: resolve the absolute source file path for a video_id."""
+    return _source_path_for(video_id, logger)
 
 
 def _source_path_for(video_id, logger):
@@ -210,9 +267,13 @@ def generate_hls(video_id, logger, source_path=None):
                 '-crf', str(settings['crf']),
                 '-vf', settings['video_filter'],
                 '-c:a', settings['acodec'], '-b:a', '128k',
+                # Force a keyframe every SEGMENT_SECONDS so segment cuts are
+                # deterministic and align with the synthesized VOD playlist.
+                '-force_key_frames', 'expr:gte(t,n_forced*%d)' % SEGMENT_SECONDS,
                 '-f', 'hls',
-                '-hls_time', '6',
+                '-hls_time', str(SEGMENT_SECONDS),
                 '-hls_list_size', '0',
+                '-hls_flags', 'temp_file',
                 '-hls_segment_filename', os.path.join(cache_dir, 'seg_%05d.ts'),
                 playlist_path,
             ]
@@ -269,6 +330,71 @@ def generate_hls(video_id, logger, source_path=None):
                 return None
 
     return cache_dir
+
+
+def segment_count_for_duration(duration):
+    """Number of HLS segments for a source of the given duration (seconds)."""
+    if not duration or duration <= 0:
+        return 0
+    return int(math.ceil(duration / float(SEGMENT_SECONDS)))
+
+
+def build_vod_playlist(duration):
+    """Build a complete VOD m3u8 string for a source of the given duration.
+
+    Emits the full segment list with #EXT-X-PLAYLIST-TYPE:VOD and
+    #EXT-X-ENDLIST up front so HLS clients treat the stream as VOD and play
+    from seg_00000 instead of latching the live edge. Returns None if the
+    duration is unknown so callers can fall back to FFmpeg's own playlist.
+    """
+    n = segment_count_for_duration(duration)
+    if n <= 0:
+        return None
+    lines = [
+        '#EXTM3U',
+        '#EXT-X-VERSION:3',
+        '#EXT-X-TARGETDURATION:%d' % SEGMENT_SECONDS,
+        '#EXT-X-MEDIA-SEQUENCE:0',
+        '#EXT-X-PLAYLIST-TYPE:VOD',
+    ]
+    remaining = float(duration)
+    for i in range(n):
+        seg_dur = float(SEGMENT_SECONDS) if remaining >= SEGMENT_SECONDS else remaining
+        lines.append('#EXTINF:%.6f,' % seg_dur)
+        lines.append('seg_%05d.ts' % i)
+        remaining -= SEGMENT_SECONDS
+    lines.append('#EXT-X-ENDLIST')
+    return '\n'.join(lines) + '\n'
+
+
+def wait_for_segment(cache_dir, index, key, timeout=30.0, interval=0.2):
+    """Block until segment `index` is on disk, or give up.
+
+    Segments are written via the hls `temp_file` flag and renamed atomically,
+    so a present, non-empty seg file is complete. Returns the segment path on
+    success, or None if it never appears (timeout, or the encode exited
+    without producing it). Bumps the in-memory last_request while waiting so
+    the reaper doesn't kill the encode out from under a blocked client.
+    """
+    seg_path = os.path.join(cache_dir, 'seg_%05d.ts' % index)
+    deadline = time.time() + timeout
+    while True:
+        if os.path.exists(seg_path) and os.path.getsize(seg_path) > 0:
+            return seg_path
+        # If the encode has exited and the file still isn't here, it never will.
+        running = _is_running(key)
+        with _active_lock:
+            item = _active.get(key)
+            if item:
+                item['last_request'] = time.time()
+        if not running:
+            # One last check to avoid a race where the file landed as we checked.
+            if os.path.exists(seg_path) and os.path.getsize(seg_path) > 0:
+                return seg_path
+            return None
+        if time.time() >= deadline:
+            return None
+        time.sleep(interval)
 
 
 def touch_cache_access(video_id, settings=None):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1373,6 +1373,80 @@ def test_video_codec_fields_and_hls(client):
         shutil.rmtree(os.path.dirname(cache_dir), ignore_errors=True)
 
 
+def test_build_vod_playlist_is_stable_vod():
+    """Synthesized playlist is a complete VOD list with ENDLIST (issue #24)."""
+    from transcoder import build_vod_playlist, segment_count_for_duration, SEGMENT_SECONDS
+
+    # 20s @ 6s segments -> 4 segments (6, 6, 6, 2)
+    assert segment_count_for_duration(20.0) == 4
+    body = build_vod_playlist(20.0)
+    lines = body.splitlines()
+
+    assert lines[0] == '#EXTM3U'
+    assert '#EXT-X-PLAYLIST-TYPE:VOD' in lines
+    assert '#EXT-X-TARGETDURATION:%d' % SEGMENT_SECONDS in lines
+    assert lines[-1] == '#EXT-X-ENDLIST'
+
+    seg_lines = [l for l in lines if l.startswith('seg_')]
+    assert seg_lines == ['seg_00000.ts', 'seg_00001.ts', 'seg_00002.ts', 'seg_00003.ts']
+
+    # Last segment carries the remainder duration, not a full SEGMENT_SECONDS.
+    inf = [l for l in lines if l.startswith('#EXTINF:')]
+    assert inf[0] == '#EXTINF:6.000000,'
+    assert inf[-1] == '#EXTINF:2.000000,'
+
+
+def test_build_vod_playlist_unknown_duration():
+    """Unknown/zero duration returns None so the caller can fall back."""
+    from transcoder import build_vod_playlist, segment_count_for_duration
+
+    assert build_vod_playlist(None) is None
+    assert build_vod_playlist(0) is None
+    assert segment_count_for_duration(None) == 0
+
+
+def test_wait_for_segment_blocks_then_returns(tmp_path):
+    """wait_for_segment blocks until the file lands, instead of 404-ing."""
+    import threading
+    from transcoder import wait_for_segment, _active, _active_lock
+
+    cache_dir = str(tmp_path)
+    key = ('WaitSegVid', 'deadbeef')
+    seg_path = os.path.join(cache_dir, 'seg_00002.ts')
+
+    # Register a fake running encode so wait_for_segment keeps polling.
+    class _FakeProc:
+        def poll(self):
+            return None
+    with _active_lock:
+        _active[key] = {'process': _FakeProc(), 'last_request': time.time(), 'dir': cache_dir}
+
+    def _write_later():
+        time.sleep(0.5)
+        with open(seg_path, 'wb') as f:
+            f.write(b'\x47' * 188)  # one TS packet
+
+    try:
+        t = threading.Thread(target=_write_later)
+        t.start()
+        result = wait_for_segment(cache_dir, 2, key, timeout=5.0, interval=0.1)
+        t.join()
+        assert result == seg_path
+    finally:
+        with _active_lock:
+            _active.pop(key, None)
+
+
+def test_wait_for_segment_gives_up_when_encode_dead(tmp_path):
+    """If the encode has exited and the file is absent, return None (-> 404)."""
+    from transcoder import wait_for_segment
+
+    # No entry in _active means _is_running() is False -> immediate give-up.
+    result = wait_for_segment(str(tmp_path), 0, ('NoSuchVid', 'cafe'),
+                              timeout=5.0, interval=0.1)
+    assert result is None
+
+
 def test_apple_direct_routing_detection():
     """is_apple_direct recognizes H264+AAC+mp4 and rejects everything else."""
     from transcoder import is_apple_direct


### PR DESCRIPTION
Closes #24.

## Problem
First play of a not-yet-finished transcode was hostile to standard HLS clients (AVPlayer):
1. The endpoint served FFmpeg's growing **live** playlist (no `#EXT-X-ENDLIST`), so AVPlayer latched the live edge and stalled indefinitely — even after the backend transcode finished.
2. The segment endpoint **hard-404'd instantly** for any listed-but-not-yet-written segment, failing the player item (`The requested URL was not found on this server.`).

## Fix
- **Stable VOD playlist up front** (`transcode_playlist`): synthesize a complete m3u8 from the source duration — full segment list, `#EXT-X-PLAYLIST-TYPE:VOD`, `#EXT-X-ENDLIST` — from the very first request. Clients treat it as VOD and play from `seg_00000` instead of latching the live edge. Falls back to FFmpeg's playlist if duration is unknown.
- **Deterministic segment boundaries** (`generate_hls`): `-force_key_frames 'expr:gte(t,n_forced*6)'` + `-hls_flags temp_file` so FFmpeg's produced segment count equals `ceil(duration/6)` and matches the synthesized playlist (and a `.ts` on disk is always complete via atomic rename).
- **Long-poll segments** (`transcode_segment`): block until FFmpeg writes the requested segment (restarting a reaped encode if needed) instead of instant 404. 404 only on a genuinely out-of-range index or timeout (`VAULTTUBE_TRANSCODE_SEGMENT_TIMEOUT`, default 30s).

## Verification
- Full suite: **95 passed** (4 new unit tests: playlist shape/ENDLIST/remainder, unknown-duration fallback, segment block-then-return, give-up-when-encode-dead; existing e2e HLS test still green).
- **Production container**: ran the exact new FFmpeg command on three real 4K sources — produced segments == `ceil(duration/6)`, contiguous from 0 (20/20 on each), confirming the synthetic playlist matches FFmpeg's real output.

## Follow-up
Once this lands, the iOS client can drop its stall/failure watchdog and the first-play spinner described in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)